### PR TITLE
WIP: Magistral model competition and routing

### DIFF
--- a/packages/magistral/COMPETITION_LEADERBOARD.md
+++ b/packages/magistral/COMPETITION_LEADERBOARD.md
@@ -1,0 +1,121 @@
+# 🏆 Magistral Model Competition Leaderboard
+
+_Generated dynamically on: 12/07/2026 18:41:33_
+
+This leaderboard ranks models based on direct head-to-head competition across three standard
+representative tasks (Guide RAG Synthesis, Inox VM Code Generation, and JSON Parameter Extraction).
+
+### Overall Rankings
+
+|  Rank   | Model / Node                                                | Competitive Score | Quality Score | Speed (tokens/s) | Avg Latency | Success Rate |
+| :-----: | :---------------------------------------------------------- | :---------------: | :-----------: | :--------------: | :---------: | :----------: |
+| **#1**  | groq-strong (`llama-3.3-70b-versatile`)                     |      **100**      |     100%      |      112/s       |    259ms    |     100%     |
+| **#2**  | mistral-fast (`mistral-small-latest`)                       |      **83**       |     100%      |       43/s       |    734ms    |     100%     |
+| **#3**  | groq-fast (`llama-3.1-8b-instant`)                          |      **81**       |      90%      |       54/s       |    547ms    |     100%     |
+| **#4**  | mistral-strong (`mistral-large-latest`)                     |      **80**       |     100%      |       32/s       |    946ms    |     100%     |
+| **#5**  | gemini-fast (`gemini-2.5-flash`)                            |      **77**       |     100%      |       22/s       |   1362ms    |     100%     |
+| **#6**  | openai-strong (`gpt-4o`)                                    |      **75**       |      90%      |       34/s       |    912ms    |     100%     |
+| **#7**  | openai-fast (`gpt-4o-mini`)                                 |      **71**       |      90%      |       21/s       |   1229ms    |     100%     |
+| **#8**  | ollama-fallback (`qwen2.5:3b`)                              |      **66**       |      90%      |       4/s        |   11011ms   |     100%     |
+| **#9**  | agent-claude (`claude-code`)                                |      **36**       |      20%      |       19/s       |    396ms    |     100%     |
+| **#10** | agent-codex (`codex`)                                       |      **36**       |      20%      |       19/s       |    392ms    |     100%     |
+| **#11** | agent-grok (`grok-build`)                                   |      **35**       |      20%      |       15/s       |    476ms    |     100%     |
+| **#12** | together-strong (`meta-llama/Llama-3.1-70B-Instruct-Turbo`) |       **0**       |      0%       |       0/s        |     0ms     |      0%      |
+
+### Detailed Task Breakdowns
+
+#### Model: groq-strong (llama-3.3-70b-versatile)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                             |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------------------ |
+| Guide RAG Synthesis       |    ✓    |  284ms  | 190/s |     100%      | Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    |  212ms  | 47/s  |     100%      | Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    |  281ms  | 100/s |     100%      | Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)                                    |
+
+#### Model: mistral-fast (mistral-small-latest)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                             |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------------------ |
+| Guide RAG Synthesis       |    ✓    | 1134ms  | 51/s  |     100%      | Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    |  562ms  | 14/s  |     100%      | Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    |  506ms  | 63/s  |     100%      | Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)                                    |
+
+#### Model: groq-fast (llama-3.1-8b-instant)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                             |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------------------ |
+| Guide RAG Synthesis       |    ✓    | 1028ms  | 54/s  |     100%      | Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    |  207ms  | 43/s  |     100%      | Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    |  405ms  | 64/s  |      70%      | Valid JSON parsed (+4), Correct locale 'fr' (+3), Missing needs_rag field or wrong type                             |
+
+#### Model: mistral-strong (mistral-large-latest)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                             |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------------------ |
+| Guide RAG Synthesis       |    ✓    | 1414ms  | 43/s  |     100%      | Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    |  575ms  | 14/s  |     100%      | Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    |  849ms  | 38/s  |     100%      | Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)                                    |
+
+#### Model: gemini-fast (gemini-2.5-flash)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                             |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------------------ |
+| Guide RAG Synthesis       |    ✓    | 1722ms  | 34/s  |     100%      | Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    |  769ms  | 12/s  |     100%      | Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    | 1595ms  | 20/s  |     100%      | Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)                                    |
+
+#### Model: openai-strong (gpt-4o)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                             |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------------------ |
+| Guide RAG Synthesis       |    ✓    |  973ms  | 57/s  |     100%      | Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    | 1005ms  |  7/s  |     100%      | Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    |  759ms  | 38/s  |      70%      | Valid JSON parsed (+4), Correct locale 'fr' (+3), Missing needs_rag field or wrong type                             |
+
+#### Model: openai-fast (gpt-4o-mini)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                             |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------------------ |
+| Guide RAG Synthesis       |    ✓    | 1877ms  | 29/s  |     100%      | Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    |  853ms  |  8/s  |     100%      | Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    |  957ms  | 25/s  |      70%      | Valid JSON parsed (+4), Correct locale 'fr' (+3), Missing needs_rag field or wrong type                             |
+
+#### Model: ollama-fallback (qwen2.5:3b)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                          |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :--------------------------------------------------------------------------------------------------------------- |
+| Guide RAG Synthesis       |    ✓    | 22944ms |  5/s  |      70%      | Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Response too short or verbose |
+| Inox VM Code Generation   |    ✓    | 3143ms  |  3/s  |     100%      | Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)                                  |
+| JSON Parameter Extraction |    ✓    | 6947ms  |  4/s  |     100%      | Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)                                 |
+
+#### Model: agent-claude (claude-code)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                  |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------- |
+| Guide RAG Synthesis       |    ✓    |  469ms  | 15/s  |      30%      | Missing keyword 'Developer-Human-in-the-Loop', Missing source citation, Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    |  337ms  | 22/s  |      30%      | No code block syntax, Missing target value 42, Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    |  383ms  | 19/s  |      0%       | Failed to parse JSON                                                                                     |
+
+#### Model: agent-codex (codex)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                  |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------- |
+| Guide RAG Synthesis       |    ✓    |  421ms  | 17/s  |      30%      | Missing keyword 'Developer-Human-in-the-Loop', Missing source citation, Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    |  387ms  | 19/s  |      30%      | No code block syntax, Missing target value 42, Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    |  368ms  | 20/s  |      0%       | Failed to parse JSON                                                                                     |
+
+#### Model: agent-grok (grok-build)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details                                                                                                  |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :------------------------------------------------------------------------------------------------------- |
+| Guide RAG Synthesis       |    ✓    |  406ms  | 18/s  |      30%      | Missing keyword 'Developer-Human-in-the-Loop', Missing source citation, Appropriate response length (+3) |
+| Inox VM Code Generation   |    ✓    |  482ms  | 15/s  |      30%      | No code block syntax, Missing target value 42, Strictly concise (+3)                                     |
+| JSON Parameter Extraction |    ✓    |  539ms  | 13/s  |      0%       | Failed to parse JSON                                                                                     |
+
+#### Model: together-strong (meta-llama/Llama-3.1-70B-Instruct-Turbo)
+
+| Task                      | Success | Latency | Speed | Quality Score | Details         |
+| :------------------------ | :-----: | :-----: | :---: | :-----------: | :-------------- |
+| Guide RAG Synthesis       |   ❌    |   0ms   |  0/s  |      0%       | Error: HTTP 401 |
+| Inox VM Code Generation   |   ❌    |   0ms   |  0/s  |      0%       | Error: HTTP 401 |
+| JSON Parameter Extraction |   ❌    |   0ms   |  0/s  |      0%       | Error: HTTP 401 |

--- a/packages/magistral/competition-results.json
+++ b/packages/magistral/competition-results.json
@@ -1,0 +1,509 @@
+{
+  "generatedAt": "2026-07-12T16:41:33.758Z",
+  "leaderboard": [
+    {
+      "nodeId": "groq-strong",
+      "model": "llama-3.3-70b-versatile",
+      "tier": "strong",
+      "successRate": 100,
+      "avgScore": 100,
+      "avgLatency": 259,
+      "avgSpeed": 112,
+      "competitiveScore": 100,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 284,
+          "tokensPerSec": 190,
+          "score": 100,
+          "details": "Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3)",
+          "promptTokens": 145,
+          "completionTokens": 54
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 212,
+          "tokensPerSec": 47,
+          "score": 100,
+          "details": "Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)",
+          "promptTokens": 74,
+          "completionTokens": 10
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 281,
+          "tokensPerSec": 100,
+          "score": 100,
+          "details": "Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)",
+          "promptTokens": 86,
+          "completionTokens": 28
+        }
+      ]
+    },
+    {
+      "nodeId": "mistral-fast",
+      "model": "mistral-small-latest",
+      "tier": "fast",
+      "successRate": 100,
+      "avgScore": 100,
+      "avgLatency": 734,
+      "avgSpeed": 43,
+      "competitiveScore": 83,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 1134,
+          "tokensPerSec": 51,
+          "score": 100,
+          "details": "Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3)",
+          "promptTokens": 131,
+          "completionTokens": 58
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 562,
+          "tokensPerSec": 14,
+          "score": 100,
+          "details": "Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)",
+          "promptTokens": 57,
+          "completionTokens": 8
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 506,
+          "tokensPerSec": 63,
+          "score": 100,
+          "details": "Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)",
+          "promptTokens": 69,
+          "completionTokens": 32
+        }
+      ]
+    },
+    {
+      "nodeId": "groq-fast",
+      "model": "llama-3.1-8b-instant",
+      "tier": "fast",
+      "successRate": 100,
+      "avgScore": 90,
+      "avgLatency": 547,
+      "avgSpeed": 54,
+      "competitiveScore": 81,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 1028,
+          "tokensPerSec": 54,
+          "score": 100,
+          "details": "Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3)",
+          "promptTokens": 145,
+          "completionTokens": 55
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 207,
+          "tokensPerSec": 43,
+          "score": 100,
+          "details": "Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)",
+          "promptTokens": 74,
+          "completionTokens": 9
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 405,
+          "tokensPerSec": 64,
+          "score": 70,
+          "details": "Valid JSON parsed (+4), Correct locale 'fr' (+3), Missing needs_rag field or wrong type",
+          "promptTokens": 86,
+          "completionTokens": 26
+        }
+      ]
+    },
+    {
+      "nodeId": "mistral-strong",
+      "model": "mistral-large-latest",
+      "tier": "strong",
+      "successRate": 100,
+      "avgScore": 100,
+      "avgLatency": 946,
+      "avgSpeed": 32,
+      "competitiveScore": 80,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 1414,
+          "tokensPerSec": 43,
+          "score": 100,
+          "details": "Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3)",
+          "promptTokens": 119,
+          "completionTokens": 61
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 575,
+          "tokensPerSec": 14,
+          "score": 100,
+          "details": "Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)",
+          "promptTokens": 45,
+          "completionTokens": 8
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 849,
+          "tokensPerSec": 38,
+          "score": 100,
+          "details": "Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)",
+          "promptTokens": 57,
+          "completionTokens": 32
+        }
+      ]
+    },
+    {
+      "nodeId": "gemini-fast",
+      "model": "gemini-2.5-flash",
+      "tier": "fast",
+      "successRate": 100,
+      "avgScore": 100,
+      "avgLatency": 1362,
+      "avgSpeed": 22,
+      "competitiveScore": 77,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 1722,
+          "tokensPerSec": 34,
+          "score": 100,
+          "details": "Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3)",
+          "promptTokens": 120,
+          "completionTokens": 59
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 769,
+          "tokensPerSec": 12,
+          "score": 100,
+          "details": "Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)",
+          "promptTokens": 43,
+          "completionTokens": 9
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 1595,
+          "tokensPerSec": 20,
+          "score": 100,
+          "details": "Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)",
+          "promptTokens": 52,
+          "completionTokens": 32
+        }
+      ]
+    },
+    {
+      "nodeId": "openai-strong",
+      "model": "gpt-4o",
+      "tier": "strong",
+      "successRate": 100,
+      "avgScore": 90,
+      "avgLatency": 912,
+      "avgSpeed": 34,
+      "competitiveScore": 75,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 973,
+          "tokensPerSec": 57,
+          "score": 100,
+          "details": "Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3)",
+          "promptTokens": 118,
+          "completionTokens": 55
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 1005,
+          "tokensPerSec": 7,
+          "score": 100,
+          "details": "Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)",
+          "promptTokens": 50,
+          "completionTokens": 7
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 759,
+          "tokensPerSec": 38,
+          "score": 70,
+          "details": "Valid JSON parsed (+4), Correct locale 'fr' (+3), Missing needs_rag field or wrong type",
+          "promptTokens": 58,
+          "completionTokens": 29
+        }
+      ]
+    },
+    {
+      "nodeId": "openai-fast",
+      "model": "gpt-4o-mini",
+      "tier": "fast",
+      "successRate": 100,
+      "avgScore": 90,
+      "avgLatency": 1229,
+      "avgSpeed": 21,
+      "competitiveScore": 71,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 1877,
+          "tokensPerSec": 29,
+          "score": 100,
+          "details": "Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Appropriate response length (+3)",
+          "promptTokens": 118,
+          "completionTokens": 55
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 853,
+          "tokensPerSec": 8,
+          "score": 100,
+          "details": "Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)",
+          "promptTokens": 50,
+          "completionTokens": 7
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 957,
+          "tokensPerSec": 25,
+          "score": 70,
+          "details": "Valid JSON parsed (+4), Correct locale 'fr' (+3), Missing needs_rag field or wrong type",
+          "promptTokens": 58,
+          "completionTokens": 24
+        }
+      ]
+    },
+    {
+      "nodeId": "ollama-fallback",
+      "model": "qwen2.5:3b",
+      "tier": "fallback",
+      "successRate": 100,
+      "avgScore": 90,
+      "avgLatency": 11011,
+      "avgSpeed": 4,
+      "competitiveScore": 66,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 22944,
+          "tokensPerSec": 5,
+          "score": 70,
+          "details": "Found 'Developer-Human-in-the-Loop' (+3), Found exact source citation format (+4), Response too short or verbose",
+          "promptTokens": 127,
+          "completionTokens": 114
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 3143,
+          "tokensPerSec": 3,
+          "score": 100,
+          "details": "Outputted clean code block (+3), Contains number 42 (+4), Strictly concise (+3)",
+          "promptTokens": 53,
+          "completionTokens": 9
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 6947,
+          "tokensPerSec": 4,
+          "score": 100,
+          "details": "Valid JSON parsed (+4), Correct locale 'fr' (+3), Correct needs_rag boolean (+3)",
+          "promptTokens": 64,
+          "completionTokens": 29
+        }
+      ]
+    },
+    {
+      "nodeId": "agent-claude",
+      "model": "claude-code",
+      "tier": "agent",
+      "successRate": 100,
+      "avgScore": 20,
+      "avgLatency": 396,
+      "avgSpeed": 19,
+      "competitiveScore": 36,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 469,
+          "tokensPerSec": 15,
+          "score": 30,
+          "details": "Missing keyword 'Developer-Human-in-the-Loop', Missing source citation, Appropriate response length (+3)",
+          "promptTokens": 0,
+          "completionTokens": 0
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 337,
+          "tokensPerSec": 22,
+          "score": 30,
+          "details": "No code block syntax, Missing target value 42, Strictly concise (+3)",
+          "promptTokens": 0,
+          "completionTokens": 0
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 383,
+          "tokensPerSec": 19,
+          "score": 0,
+          "details": "Failed to parse JSON",
+          "promptTokens": 0,
+          "completionTokens": 0
+        }
+      ]
+    },
+    {
+      "nodeId": "agent-codex",
+      "model": "codex",
+      "tier": "agent",
+      "successRate": 100,
+      "avgScore": 20,
+      "avgLatency": 392,
+      "avgSpeed": 19,
+      "competitiveScore": 36,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 421,
+          "tokensPerSec": 17,
+          "score": 30,
+          "details": "Missing keyword 'Developer-Human-in-the-Loop', Missing source citation, Appropriate response length (+3)",
+          "promptTokens": 0,
+          "completionTokens": 0
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 387,
+          "tokensPerSec": 19,
+          "score": 30,
+          "details": "No code block syntax, Missing target value 42, Strictly concise (+3)",
+          "promptTokens": 0,
+          "completionTokens": 0
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 368,
+          "tokensPerSec": 20,
+          "score": 0,
+          "details": "Failed to parse JSON",
+          "promptTokens": 0,
+          "completionTokens": 0
+        }
+      ]
+    },
+    {
+      "nodeId": "agent-grok",
+      "model": "grok-build",
+      "tier": "agent",
+      "successRate": 100,
+      "avgScore": 20,
+      "avgLatency": 476,
+      "avgSpeed": 15,
+      "competitiveScore": 35,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": true,
+          "latency": 406,
+          "tokensPerSec": 18,
+          "score": 30,
+          "details": "Missing keyword 'Developer-Human-in-the-Loop', Missing source citation, Appropriate response length (+3)",
+          "promptTokens": 0,
+          "completionTokens": 0
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": true,
+          "latency": 482,
+          "tokensPerSec": 15,
+          "score": 30,
+          "details": "No code block syntax, Missing target value 42, Strictly concise (+3)",
+          "promptTokens": 0,
+          "completionTokens": 0
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": true,
+          "latency": 539,
+          "tokensPerSec": 13,
+          "score": 0,
+          "details": "Failed to parse JSON",
+          "promptTokens": 0,
+          "completionTokens": 0
+        }
+      ]
+    },
+    {
+      "nodeId": "together-strong",
+      "model": "meta-llama/Llama-3.1-70B-Instruct-Turbo",
+      "tier": "strong",
+      "successRate": 0,
+      "avgScore": 0,
+      "avgLatency": 0,
+      "avgSpeed": 0,
+      "competitiveScore": 0,
+      "results": [
+        {
+          "testName": "Guide RAG Synthesis",
+          "success": false,
+          "latency": 0,
+          "tokensPerSec": 0,
+          "score": 0,
+          "details": "Error: HTTP 401",
+          "promptTokens": 0,
+          "completionTokens": 0
+        },
+        {
+          "testName": "Inox VM Code Generation",
+          "success": false,
+          "latency": 0,
+          "tokensPerSec": 0,
+          "score": 0,
+          "details": "Error: HTTP 401",
+          "promptTokens": 0,
+          "completionTokens": 0
+        },
+        {
+          "testName": "JSON Parameter Extraction",
+          "success": false,
+          "latency": 0,
+          "tokensPerSec": 0,
+          "score": 0,
+          "details": "Error: HTTP 401",
+          "promptTokens": 0,
+          "completionTokens": 0
+        }
+      ]
+    }
+  ]
+}

--- a/packages/magistral/registry/maps/default.json
+++ b/packages/magistral/registry/maps/default.json
@@ -8,10 +8,114 @@
     "weight": 10
   },
   {
+    "id": "groq-strong",
+    "url": "https://api.groq.com/openai/v1/chat/completions",
+    "model": "llama-3.3-70b-versatile",
+    "tier": "strong",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "openai-fast",
+    "url": "https://api.openai.com/v1/chat/completions",
+    "model": "gpt-4o-mini",
+    "tier": "fast",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "openai-strong",
+    "url": "https://api.openai.com/v1/chat/completions",
+    "model": "gpt-4o",
+    "tier": "strong",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "mistral-fast",
+    "url": "https://api.mistral.ai/v1/chat/completions",
+    "model": "mistral-small-latest",
+    "tier": "fast",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "mistral-strong",
+    "url": "https://api.mistral.ai/v1/chat/completions",
+    "model": "mistral-large-latest",
+    "tier": "strong",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "gemini-fast",
+    "url": "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+    "model": "gemini-2.5-flash",
+    "tier": "fast",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
     "id": "together-strong",
     "url": "https://api.together.xyz/v1/chat/completions",
     "model": "meta-llama/Llama-3.1-70B-Instruct-Turbo",
     "tier": "strong",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "agent-grok",
+    "url": "http://127.0.0.1:8793/v1/chat/completions",
+    "model": "grok-build",
+    "tier": "agent",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "agent-grok-alias",
+    "url": "http://127.0.0.1:8793/v1/chat/completions",
+    "model": "grok",
+    "tier": "agent",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "agent-claude",
+    "url": "http://127.0.0.1:8793/v1/chat/completions",
+    "model": "claude-code",
+    "tier": "agent",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "agent-claude-alias",
+    "url": "http://127.0.0.1:8793/v1/chat/completions",
+    "model": "claude",
+    "tier": "agent",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "agent-codex",
+    "url": "http://127.0.0.1:8793/v1/chat/completions",
+    "model": "codex",
+    "tier": "agent",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "agent-antigravity",
+    "url": "http://127.0.0.1:8793/v1/chat/completions",
+    "model": "antigravity",
+    "tier": "agent",
+    "blueprint_id": "coding",
+    "weight": 10
+  },
+  {
+    "id": "agent-agy",
+    "url": "http://127.0.0.1:8793/v1/chat/completions",
+    "model": "agy",
+    "tier": "agent",
     "blueprint_id": "coding",
     "weight": 10
   },

--- a/packages/magistral/scripts/debug-agent-gateway.js
+++ b/packages/magistral/scripts/debug-agent-gateway.js
@@ -1,0 +1,31 @@
+async function testAgentGateway() {
+  const url = "http://127.0.0.1:8793/v1/chat/completions";
+  const body = {
+    model: "grok-build",
+    messages: [
+      {
+        role: "user",
+        content:
+          "Extract locale (2-letter code), intent, and needs_rag (boolean) from this prompt: 'Recherche-moi les documents sur la Corse en français'",
+      },
+    ],
+    temperature: 0.1,
+    max_tokens: 150,
+  };
+
+  try {
+    console.log("Testing Agent Gateway...");
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    console.log(`Status: ${res.status} ${res.statusText}`);
+    const data = await res.json();
+    console.log("Response:", JSON.stringify(data, null, 2));
+  } catch (e) {
+    console.error("Agent Gateway test failed:", e.message);
+  }
+}
+
+testAgentGateway();

--- a/packages/magistral/scripts/debug-failures.js
+++ b/packages/magistral/scripts/debug-failures.js
@@ -1,0 +1,64 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const MAGISTRAL_DIR = path.resolve(SCRIPT_DIR, "..");
+
+// Load env
+function loadEnvFromFile(envPath) {
+  if (fs.existsSync(envPath)) {
+    const lines = fs.readFileSync(envPath, "utf-8").split("\n");
+    for (const line of lines) {
+      const match = line.match(/^\s*([\w.-]+)\s*=\s*(.*)\s*$/);
+      if (match) {
+        const key = match[1];
+        let val = match[2].trim();
+        if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+        if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+        if (!process.env[key]) {
+          process.env[key] = val;
+        }
+      }
+    }
+  }
+}
+loadEnvFromFile(path.resolve(MAGISTRAL_DIR, "../../../survey/.env"));
+loadEnvFromFile(path.resolve(MAGISTRAL_DIR, "../.env"));
+
+async function testGeminiJson() {
+  const url = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${process.env.GEMINI_API_KEY}`,
+  };
+  const body = {
+    model: "gemini-2.5-flash",
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are a JSON parameter extractor. Return ONLY valid JSON with no conversational text.",
+      },
+      {
+        role: "user",
+        content:
+          "Extract locale (2-letter code), intent, and needs_rag (boolean) from this prompt: 'Recherche-moi les documents sur la Corse en français'",
+      },
+    ],
+    temperature: 0.1,
+    // max_tokens removed
+  };
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  console.log("Gemini Output content (no max_tokens):");
+  console.log(data.choices?.[0]?.message?.content);
+  console.log("Full data:", JSON.stringify(data, null, 2));
+}
+
+testGeminiJson();

--- a/packages/magistral/scripts/leaderboard.js
+++ b/packages/magistral/scripts/leaderboard.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const MAGISTRAL_DIR = path.resolve(SCRIPT_DIR, "..");
+const LOG_FILE = path.join(MAGISTRAL_DIR, ".magistral-traffic.log");
+
+if (!fs.existsSync(LOG_FILE)) {
+  console.log("No traffic logs found. Run some queries first!");
+  process.exit(0);
+}
+
+const raw = fs.readFileSync(LOG_FILE, "utf-8").trim();
+if (!raw) {
+  console.log("Traffic log file is empty.");
+  process.exit(0);
+}
+
+const entries = raw
+  .split("\n")
+  .map((line, idx) => {
+    try {
+      return JSON.parse(line);
+    } catch (e) {
+      console.warn(`[Warning] Failed to parse log line ${idx + 1}: ${e.message}`);
+      return null;
+    }
+  })
+  .filter(Boolean);
+
+const stats = {};
+
+for (const entry of entries) {
+  const key = `${entry.nodeId} (${entry.model})`;
+  if (!stats[key]) {
+    stats[key] = {
+      nodeId: entry.nodeId,
+      model: entry.model,
+      requests: 0,
+      successes: 0,
+      failures: 0,
+      totalLatency: 0,
+      promptTokens: 0,
+      completionTokens: 0,
+    };
+  }
+
+  const s = stats[key];
+  s.requests++;
+  if (entry.status === 200) {
+    s.successes++;
+    s.totalLatency += entry.latencyMs || 0;
+    s.promptTokens += entry.promptTokens || 0;
+    s.completionTokens += entry.completionTokens || 0;
+  } else {
+    s.failures++;
+  }
+}
+
+const leaderboard = Object.values(stats)
+  .map((s) => {
+    const avgLatency = s.successes > 0 ? Math.round(s.totalLatency / s.successes) : 0;
+    const successRate = s.requests > 0 ? Math.round((s.successes / s.requests) * 100) : 0;
+    const tokensPerSec =
+      s.totalLatency > 0 ? Math.round(s.completionTokens / (s.totalLatency / 1000)) : 0;
+    return {
+      ...s,
+      avgLatency,
+      successRate,
+      tokensPerSec,
+    };
+  })
+  .sort((a, b) => b.requests - a.requests);
+
+console.log("\n🏆 ========================================================= 🏆");
+console.log("                 MAGISTRAL MODEL LEADERBOARD                  ");
+console.log("🏆 ========================================================= 🏆\n");
+
+const header =
+  String().padEnd(30) + " | Req | Success | Avg Latency | Tokens/s | Input Tok | Output Tok";
+console.log(header);
+console.log("-".repeat(header.length));
+
+for (const item of leaderboard) {
+  const label = `${item.nodeId} (${item.model})`.slice(0, 30).padEnd(30);
+  const reqStr = String(item.requests).padStart(3);
+  const succStr = `${item.successRate}%`.padStart(7);
+  const latStr = `${item.avgLatency}ms`.padStart(11);
+  const tpsStr = `${item.tokensPerSec}/s`.padStart(8);
+  const inStr = String(item.promptTokens).padStart(9);
+  const outStr = String(item.completionTokens).padStart(10);
+  console.log(`${label} | ${reqStr} | ${succStr} | ${latStr} | ${tpsStr} | ${inStr} | ${outStr}`);
+}
+console.log();

--- a/packages/magistral/scripts/run-competition.js
+++ b/packages/magistral/scripts/run-competition.js
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const MAGISTRAL_DIR = path.resolve(SCRIPT_DIR, "..");
+const MAP_FILE = path.join(MAGISTRAL_DIR, "registry", "maps", "default.json");
+const REPORT_FILE = path.join(MAGISTRAL_DIR, "COMPETITION_LEADERBOARD.md");
+const RESULTS_JSON = path.join(MAGISTRAL_DIR, "competition-results.json");
+
+// 1. Load environment variables
+function loadEnvFromFile(envPath) {
+  try {
+    if (fs.existsSync(envPath)) {
+      const lines = fs.readFileSync(envPath, "utf-8").split("\n");
+      for (const line of lines) {
+        const match = line.match(/^\s*(?:export\s+)?([\w.-]+)\s*=\s*(.*)\s*$/);
+        if (match) {
+          const key = match[1];
+          let val = match[2].trim();
+          if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+          if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+          if (!process.env[key] || process.env[key] === "") {
+            process.env[key] = val;
+          }
+        }
+      }
+    }
+  } catch (e) {
+    console.warn(`Failed to load env file: ${envPath}`, e.message);
+  }
+}
+
+function loadEnv() {
+  // Load survey .env (often rich in external keys)
+  loadEnvFromFile(path.resolve(MAGISTRAL_DIR, "../../../survey/.env"));
+  // Load inseme .env
+  loadEnvFromFile(path.resolve(MAGISTRAL_DIR, "../.env"));
+  // Load production secrets
+  loadEnvFromFile("/srv/cogentia/secrets/guide.env");
+  loadEnvFromFile("/srv/cogentia/secrets/ona.env");
+  loadEnvFromFile("/etc/cogentia/guide.env");
+  loadEnvFromFile("/etc/cogentia/ona.env");
+
+  // Key normalization / alias mapping
+  if (process.env.GROC_API_KEY && !process.env.GROQ_API_KEY) {
+    process.env.GROQ_API_KEY = process.env.GROC_API_KEY;
+  }
+}
+loadEnv();
+
+// Helper to get API key for a node
+function getApiKeyForNode(node) {
+  const url = node.url || "";
+  if (node.apiKey || node.api_key) return node.apiKey || node.api_key;
+  if (node.apiKeyEnv && process.env[node.apiKeyEnv]) return process.env[node.apiKeyEnv];
+  if (url.includes("groq.com")) return process.env.GROQ_API_KEY || "";
+  if (url.includes("together.xyz") || url.includes("together.ai"))
+    return process.env.TOGETHER_API_KEY || "";
+  if (url.includes("openai.com")) return process.env.OPENAI_API_KEY || "";
+  if (url.includes("anthropic.com")) return process.env.ANTHROPIC_API_KEY || "";
+  if (url.includes("mistral.ai")) return process.env.MISTRAL_API_KEY || "";
+  if (url.includes("googleapis.com") || url.includes("google.com"))
+    return process.env.GEMINI_API_KEY || "";
+  return "";
+}
+
+// 2. Define Benchmark Test Cases (representing core Inseme usage)
+const TEST_CASES = [
+  {
+    name: "Guide RAG Synthesis",
+    payload: {
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are Cogentia Guide, an AI assistant. Synthesize a concise answer using the provided context. You must cite the exact source in the format [repo:file#L12-L34] where applicable.",
+        },
+        {
+          role: "user",
+          content: `Context:\n[marenostrum:research/DHITL.md#L10-L20]: DHITL stands for Developer-Human-in-the-Loop. It is an alignment framework designed to prevent vendor capture of public cognitive infrastructure by anchoring agents to developer-validated state machines.\n\nQuestion: What is DHITL?`,
+        },
+      ],
+      temperature: 0.1,
+      max_tokens: 200,
+    },
+    evaluate: (output) => {
+      let score = 0;
+      const details = [];
+
+      if (output.toLowerCase().includes("developer-human-in-the-loop")) {
+        score += 3;
+        details.push("Found 'Developer-Human-in-the-Loop' (+3)");
+      } else {
+        details.push("Missing keyword 'Developer-Human-in-the-Loop'");
+      }
+
+      if (output.includes("[marenostrum:research/DHITL.md#L10-L20]")) {
+        score += 4;
+        details.push("Found exact source citation format (+4)");
+      } else if (output.includes("marenostrum") || output.includes("DHITL.md")) {
+        score += 2;
+        details.push("Partial source citation found (+2)");
+      } else {
+        details.push("Missing source citation");
+      }
+
+      if (output.length > 20 && output.length < 500) {
+        score += 3;
+        details.push("Appropriate response length (+3)");
+      } else {
+        details.push("Response too short or verbose");
+      }
+
+      return { score: (score / 10) * 100, details: details.join(", ") };
+    },
+  },
+  {
+    name: "Inox VM Code Generation",
+    payload: {
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are an assistant specialized in the Inox stack-based VM. Output ONLY the code block, no extra comments.",
+        },
+        {
+          role: "user",
+          content: "Write an Inox push operation to push the number 42 onto the stack.",
+        },
+      ],
+      temperature: 0.1,
+      max_tokens: 100,
+    },
+    evaluate: (output) => {
+      let score = 0;
+      const details = [];
+
+      if (output.includes("```")) {
+        score += 3;
+        details.push("Outputted clean code block (+3)");
+      } else {
+        details.push("No code block syntax");
+      }
+
+      if (output.includes("42")) {
+        score += 4;
+        details.push("Contains number 42 (+4)");
+      } else {
+        details.push("Missing target value 42");
+      }
+
+      if (output.length < 150) {
+        score += 3;
+        details.push("Strictly concise (+3)");
+      } else {
+        details.push("Contains verbose extra explanation");
+      }
+
+      return { score: (score / 10) * 100, details: details.join(", ") };
+    },
+  },
+  {
+    name: "JSON Parameter Extraction",
+    payload: {
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are a JSON parameter extractor. Return ONLY valid JSON with no conversational text.",
+        },
+        {
+          role: "user",
+          content:
+            "Extract locale (2-letter code), intent, and needs_rag (boolean) from this prompt: 'Recherche-moi les documents sur la Corse en français'",
+        },
+      ],
+      temperature: 0.1,
+      max_tokens: 150,
+    },
+    evaluate: (output) => {
+      let score = 0;
+      const details = [];
+      let parsed = null;
+
+      try {
+        const cleanJson = output.replace(/```json|```/g, "").trim();
+        parsed = JSON.parse(cleanJson);
+        score += 4;
+        details.push("Valid JSON parsed (+4)");
+      } catch (e) {
+        details.push("Failed to parse JSON");
+      }
+
+      if (parsed) {
+        if (parsed.locale === "fr") {
+          score += 3;
+          details.push("Correct locale 'fr' (+3)");
+        } else {
+          details.push(`Wrong locale: ${parsed.locale}`);
+        }
+
+        if (parsed.needs_rag === true) {
+          score += 3;
+          details.push("Correct needs_rag boolean (+3)");
+        } else {
+          details.push("Missing needs_rag field or wrong type");
+        }
+      }
+
+      return { score: (score / 10) * 100, details: details.join(", ") };
+    },
+  },
+];
+
+// 3. Execution function
+async function runModelBenchmark(node) {
+  const apiKey = getApiKeyForNode(node);
+  const headers = { "Content-Type": "application/json" };
+  if (apiKey) {
+    headers["Authorization"] = `Bearer ${apiKey}`;
+  }
+
+  const results = [];
+  console.log(`\n🤖 Testing Node: ${node.id} (${node.model})`);
+
+  for (const tc of TEST_CASES) {
+    const body = {
+      model: node.model,
+      ...tc.payload,
+    };
+    if (node.url.includes("googleapis.com") || node.url.includes("google.com")) {
+      delete body.max_tokens;
+    }
+
+    const start = Date.now();
+    try {
+      const res = await fetch(node.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(120000), // 120 second timeout per call
+      });
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      const latency = Date.now() - start;
+      const content = data.choices?.[0]?.message?.content || "";
+      const promptTokens = data.usage?.prompt_tokens || 0;
+      const completionTokens = data.usage?.completion_tokens || 0;
+
+      const { score, details } = tc.evaluate(content);
+      const tokensPerSec =
+        latency > 0 ? Math.round((completionTokens || content.length / 4) / (latency / 1000)) : 0;
+
+      results.push({
+        testName: tc.name,
+        success: true,
+        latency,
+        tokensPerSec,
+        score,
+        details,
+        promptTokens,
+        completionTokens,
+      });
+      console.log(`  ✓ ${tc.name}: Score=${score}% Latency=${latency}ms Speed=${tokensPerSec} t/s`);
+    } catch (e) {
+      console.log(`  ❌ ${tc.name} Failed: ${e.message}`);
+      results.push({
+        testName: tc.name,
+        success: false,
+        latency: 0,
+        tokensPerSec: 0,
+        score: 0,
+        details: `Error: ${e.message}`,
+        promptTokens: 0,
+        completionTokens: 0,
+      });
+    }
+  }
+
+  return results;
+}
+
+async function main() {
+  console.log("=========================================================");
+  console.log("             MAGISTRAL PERIODIC MODEL COMPETITION        ");
+  console.log("=========================================================");
+
+  if (!fs.existsSync(MAP_FILE)) {
+    console.error(`Map file not found at: ${MAP_FILE}`);
+    process.exit(1);
+  }
+
+  const map = JSON.parse(fs.readFileSync(MAP_FILE, "utf-8"));
+  console.log(`Loaded ${map.length} models from routing map.\n`);
+
+  const leaderboard = [];
+
+  for (const node of map) {
+    const results = await runModelBenchmark(node);
+
+    const successes = results.filter((r) => r.success);
+    const successRate = Math.round((successes.length / results.length) * 100);
+    const avgScore =
+      successes.length > 0
+        ? Math.round(successes.reduce((acc, r) => acc + r.score, 0) / successes.length)
+        : 0;
+    const avgLatency =
+      successes.length > 0
+        ? Math.round(successes.reduce((acc, r) => acc + r.latency, 0) / successes.length)
+        : 0;
+    const avgSpeed =
+      successes.length > 0
+        ? Math.round(successes.reduce((acc, r) => acc + r.tokensPerSec, 0) / successes.length)
+        : 0;
+
+    // Overall competitive score: 50% Quality Score + 30% Speed + 20% Success Rate
+    // (Speed score is normalized relative to a target of 100 tokens/sec)
+    const speedScore = Math.min(100, (avgSpeed / 100) * 100);
+    const competitiveScore = Math.round(avgScore * 0.5 + speedScore * 0.3 + successRate * 0.2);
+
+    leaderboard.push({
+      nodeId: node.id,
+      model: node.model,
+      tier: node.tier,
+      successRate,
+      avgScore,
+      avgLatency,
+      avgSpeed,
+      competitiveScore,
+      results,
+    });
+  }
+
+  // Sort by competitive score descending
+  leaderboard.sort((a, b) => b.competitiveScore - a.competitiveScore);
+
+  // Generate Report Markdown
+  let report = `# 🏆 Magistral Model Competition Leaderboard\n\n`;
+  report += `*Generated dynamically on: ${new Date().toLocaleString()}*\n\n`;
+  report += `This leaderboard ranks models based on direct head-to-head competition across three standard representative tasks (Guide RAG Synthesis, Inox VM Code Generation, and JSON Parameter Extraction).\n\n`;
+  report += `### Overall Rankings\n\n`;
+  report += `| Rank | Model / Node | Competitive Score | Quality Score | Speed (tokens/s) | Avg Latency | Success Rate |\n`;
+  report += `| :---: | :--- | :---: | :---: | :---: | :---: | :---: |\n`;
+
+  leaderboard.forEach((item, index) => {
+    report += `| **#${index + 1}** | ${item.nodeId} (\`${item.model}\`) | **${item.competitiveScore}** | ${item.avgScore}% | ${item.avgSpeed}/s | ${item.avgLatency}ms | ${item.successRate}% |\n`;
+  });
+
+  report += `\n### Detailed Task Breakdowns\n\n`;
+  for (const item of leaderboard) {
+    report += `#### Model: ${item.nodeId} (${item.model})\n`;
+    report += `| Task | Success | Latency | Speed | Quality Score | Details |\n`;
+    report += `| :--- | :---: | :---: | :---: | :---: | :--- |\n`;
+    for (const r of item.results) {
+      report += `| ${r.testName} | ${r.success ? "✓" : "❌"} | ${r.latency}ms | ${r.tokensPerSec}/s | ${r.score}% | ${r.details} |\n`;
+    }
+    report += `\n`;
+  }
+
+  fs.writeFileSync(REPORT_FILE, report);
+  fs.writeFileSync(
+    RESULTS_JSON,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        leaderboard,
+      },
+      null,
+      2
+    )
+  );
+  console.log(`\nCompetition complete! Report saved to: ${REPORT_FILE}\n`);
+
+  console.log("=========================================================");
+  console.log("                 FINAL LEADERBOARD STANDINGS             ");
+  console.log("=========================================================");
+  leaderboard.forEach((item, idx) => {
+    console.log(
+      `${idx + 1}. ${item.nodeId} (${item.model}) - Score: ${item.competitiveScore}% (Quality: ${item.avgScore}%, Speed: ${item.avgSpeed} t/s, Success: ${item.successRate}%)`
+    );
+  });
+  console.log("=========================================================\n");
+}
+
+main().catch((err) => {
+  console.error("Fatal benchmark error:", err);
+});

--- a/packages/magistral/src/router.js
+++ b/packages/magistral/src/router.js
@@ -255,6 +255,8 @@ function getApiKeyForNode(node, apiKeys) {
   if (url.includes("together.xyz") || url.includes("together.ai")) return apiKeys.TOGETHER_API_KEY;
   if (url.includes("openai.com")) return apiKeys.OPENAI_API_KEY;
   if (url.includes("anthropic.com")) return apiKeys.ANTHROPIC_API_KEY;
+  if (url.includes("mistral.ai")) return apiKeys.MISTRAL_API_KEY;
+  if (url.includes("googleapis.com") || url.includes("google.com")) return apiKeys.GEMINI_API_KEY;
   return null;
 }
 
@@ -302,6 +304,9 @@ export function createRouter({
       if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
       const nodePayload = { ...payload, model: node.model };
+      if (node.url.includes("googleapis.com") || node.url.includes("google.com")) {
+        delete nodePayload.max_tokens;
+      }
 
       // Base log entry
       const logEntry = {

--- a/packages/magistral/ui/modules/magistral.js
+++ b/packages/magistral/ui/modules/magistral.js
@@ -114,11 +114,48 @@ export function initMagistral(apiEndpoint) {
         </div>
     `;
 
+  const leaderboardTab = `
+        <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4 space-y-4">
+            <div class="flex items-center justify-between">
+                <div>
+                    <h2 class="text-xs font-semibold uppercase tracking-wide text-slate-400">Model Competition Leaderboard</h2>
+                    <p class="text-[10px] text-slate-500 mt-0.5" id="leaderboard-updated-at">Last run: never</p>
+                </div>
+                <div class="flex gap-2">
+                    <button id="run-competition-btn" class="bg-emerald-600 hover:bg-emerald-500 text-white px-2.5 py-1 rounded text-[10px] font-semibold transition-colors">Run Competition</button>
+                    <button id="refresh-leaderboard-btn" class="text-[10px] text-sky-400 hover:text-sky-300">Refresh</button>
+                </div>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="w-full text-left text-[11px]">
+                    <thead class="text-slate-500 border-b border-slate-800">
+                        <tr>
+                            <th class="pb-2 font-medium text-center">Rank</th>
+                            <th class="pb-2 font-medium">Model / Node</th>
+                            <th class="pb-2 font-medium text-center">Comp. Score</th>
+                            <th class="pb-2 font-medium text-center">Quality Score</th>
+                            <th class="pb-2 font-medium text-center">Speed</th>
+                            <th class="pb-2 font-medium text-center">Avg Latency</th>
+                            <th class="pb-2 font-medium text-center">Success Rate</th>
+                        </tr>
+                    </thead>
+                    <tbody id="leaderboard-body" class="text-slate-300 divide-y divide-slate-800/50">
+                        <tr><td colspan="7" class="py-2 text-center text-slate-600">Loading...</td></tr>
+                    </tbody>
+                </table>
+            </div>
+            <div id="leaderboard-details" class="space-y-2 mt-4">
+                <!-- Collapsible detail blocks for each model -->
+            </div>
+        </div>
+    `;
+
   return {
     sidebar: sidebar,
     tabs: [
       { id: "nodes", label: "Nodes", content: nodesTab },
       { id: "explore", label: "Explore", content: exploreTab },
+      { id: "leaderboard", label: "Leaderboard", content: leaderboardTab },
       { id: "logs", label: "Logs", content: logsTab },
     ],
     onLoad: () => setupMagistralLogic(apiEndpoint),
@@ -147,6 +184,12 @@ function setupMagistralLogic(apiEndpoint) {
     logStatusFilter: document.getElementById("log-status-filter"),
     logsContainer: document.getElementById("logs-container"),
     logDetail: document.getElementById("log-detail"),
+    // Leaderboard elements
+    leaderboardBody: document.getElementById("leaderboard-body"),
+    refreshLeaderboardBtn: document.getElementById("refresh-leaderboard-btn"),
+    runCompetitionBtn: document.getElementById("run-competition-btn"),
+    leaderboardUpdatedAt: document.getElementById("leaderboard-updated-at"),
+    leaderboardDetails: document.getElementById("leaderboard-details"),
   };
 
   let autoRefreshTimer = null;
@@ -521,6 +564,137 @@ function setupMagistralLogic(apiEndpoint) {
   if (els.logNodeFilter) els.logNodeFilter.addEventListener("change", () => loadLogs(true));
   if (els.logStatusFilter) els.logStatusFilter.addEventListener("change", () => loadLogs(true));
 
+  // Leaderboard Logic (Active Competition)
+  async function loadLeaderboard() {
+    try {
+      const data = await apiFetch("/v1/magistral/competition").catch(() => null);
+      if (!data || !data.leaderboard || data.leaderboard.length === 0) {
+        els.leaderboardBody.innerHTML = `
+          <tr>
+            <td colspan="7" class="py-4 text-center text-slate-500">
+              No competition results found.<br/>
+              <span class="text-[10px]">Click "Run Competition" to launch a benchmark suite in the background.</span>
+            </td>
+          </tr>
+        `;
+        if (els.leaderboardDetails) els.leaderboardDetails.innerHTML = "";
+        if (els.leaderboardUpdatedAt) els.leaderboardUpdatedAt.textContent = "Last run: never";
+        return;
+      }
+
+      if (data.generatedAt && els.leaderboardUpdatedAt) {
+        els.leaderboardUpdatedAt.textContent = `Last run: ${new Date(data.generatedAt).toLocaleString()}`;
+      }
+
+      els.leaderboardBody.innerHTML = data.leaderboard
+        .map((item, index) => {
+          const scoreClass =
+            item.competitiveScore > 50 ? "text-emerald-400 font-bold" : "text-amber-400";
+          return `
+            <tr class="border-b border-slate-800/50 hover:bg-slate-800/30 transition-colors">
+                <td class="py-2 font-mono text-slate-500 text-center font-bold">#${index + 1}</td>
+                <td class="py-2 font-mono text-slate-200 font-medium">${item.nodeId} <span class="text-[10px] text-slate-500">(${item.model})</span></td>
+                <td class="py-2 text-center ${scoreClass} font-mono">${item.competitiveScore}%</td>
+                <td class="py-2 text-center text-slate-300 font-mono">${item.avgScore}%</td>
+                <td class="py-2 text-center text-slate-300 font-mono">${item.avgSpeed}/s</td>
+                <td class="py-2 text-center text-slate-400 font-mono">${item.avgLatency}ms</td>
+                <td class="py-2 text-center text-slate-400 font-mono">${item.successRate}%</td>
+            </tr>
+          `;
+        })
+        .join("");
+
+      if (els.leaderboardDetails) {
+        els.leaderboardDetails.innerHTML = `
+          <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500 mt-4 mb-2">Detailed Task Breakdown</h3>
+          <div class="space-y-3">
+            ${data.leaderboard
+              .map(
+                (item) => `
+              <div class="rounded-lg border border-slate-800 bg-black/40 p-3 space-y-2">
+                <div class="flex items-center justify-between">
+                  <span class="text-xs font-mono font-semibold text-slate-300">${item.nodeId}</span>
+                  <span class="text-[10px] px-2 py-0.5 rounded bg-slate-800 text-slate-400 font-mono">Score: ${item.competitiveScore}%</span>
+                </div>
+                <div class="overflow-x-auto">
+                  <table class="w-full text-left text-[10px] text-slate-400">
+                    <thead>
+                      <tr class="border-b border-slate-800 text-slate-500">
+                        <th class="pb-1 font-medium">Task</th>
+                        <th class="pb-1 font-medium text-center">Status</th>
+                        <th class="pb-1 font-medium text-center">Latency</th>
+                        <th class="pb-1 font-medium text-center">Speed</th>
+                        <th class="pb-1 font-medium text-center">Quality</th>
+                        <th class="pb-1 font-medium">Evaluation Details</th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-slate-800/30">
+                      ${item.results
+                        .map(
+                          (r) => `
+                        <tr>
+                          <td class="py-1.5 font-medium">${r.testName}</td>
+                          <td class="py-1.5 text-center">${r.success ? '<span class="text-emerald-400">✓</span>' : '<span class="text-red-400">❌</span>'}</td>
+                          <td class="py-1.5 text-center font-mono">${r.latency}ms</td>
+                          <td class="py-1.5 text-center font-mono">${r.tokensPerSec}/s</td>
+                          <td class="py-1.5 text-center font-mono">${r.score}%</td>
+                          <td class="py-1.5 text-[9px] text-slate-500 font-mono">${r.details || ""}</td>
+                        </tr>
+                      `
+                        )
+                        .join("")}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            `
+              )
+              .join("")}
+          </div>
+        `;
+      }
+    } catch (e) {
+      console.error("Leaderboard Error:", e);
+      els.leaderboardBody.innerHTML = `<tr><td colspan="7" class="py-2 text-center text-red-400">Error loading leaderboard: ${e.message}</td></tr>`;
+    }
+  }
+
+  if (els.runCompetitionBtn) {
+    els.runCompetitionBtn.addEventListener("click", async () => {
+      try {
+        els.runCompetitionBtn.disabled = true;
+        els.runCompetitionBtn.textContent = "Running...";
+        els.runCompetitionBtn.className =
+          "bg-amber-600 text-white px-2.5 py-1 rounded text-[10px] font-semibold";
+
+        await apiFetch("/v1/magistral/competition/run", { method: "POST" });
+        alert(
+          "Model competition benchmark started in the background! Please wait ~30 seconds, then click Refresh."
+        );
+      } catch (e) {
+        alert("Failed to start competition: " + e.message);
+      } finally {
+        setTimeout(() => {
+          els.runCompetitionBtn.disabled = false;
+          els.runCompetitionBtn.textContent = "Run Competition";
+          els.runCompetitionBtn.className =
+            "bg-emerald-600 hover:bg-emerald-500 text-white px-2.5 py-1 rounded text-[10px] font-semibold transition-colors";
+        }, 5000);
+      }
+    });
+  }
+
+  if (els.refreshLeaderboardBtn) {
+    els.refreshLeaderboardBtn.addEventListener("click", loadLeaderboard);
+  }
+
+  // Reload leaderboard when tab is clicked
+  window.addEventListener("tab-changed", (e) => {
+    if (e.detail.tabId === "leaderboard") {
+      loadLeaderboard();
+    }
+  });
+
   // Auto Refresh Loop (respects isLogsPaused for the container scroll state)
   setInterval(() => {
     if (document.getElementById("nodes")?.classList.contains("active")) {
@@ -530,12 +704,19 @@ function setupMagistralLogic(apiEndpoint) {
     if (logsTabEl?.classList.contains("active") && isAutoRefresh && !isLogsPaused) {
       loadLogs(true);
     }
+    const leaderboardTabEl = document.getElementById("leaderboard");
+    if (leaderboardTabEl?.classList.contains("active")) {
+      loadLeaderboard();
+    }
   }, 2500);
 
   // Initial Load
   loadMetrics();
   // Kick an initial logs load (will also populate node filter)
-  setTimeout(() => loadLogs(false), 300);
+  setTimeout(() => {
+    loadLogs(false);
+    loadLeaderboard();
+  }, 300);
 
   setupLogsFreeze();
 }

--- a/packages/models/src/ai.js
+++ b/packages/models/src/ai.js
@@ -431,10 +431,44 @@ function getMagistralRouter() {
   }
 
   const map = includeLocalFallback() ? [...cloudNodes, localFallback] : cloudNodes;
+
+  function loadEnvFromFile(envPath) {
+    try {
+      if (fs.existsSync(envPath)) {
+        const content = fs.readFileSync(envPath, "utf-8");
+        const lines = content.split("\n");
+        for (const line of lines) {
+          const match = line.match(/^\s*(?:export\s+)?([\w.-]+)\s*=\s*(.*)\s*$/);
+          if (match) {
+            const key = match[1];
+            let val = match[2].trim();
+            if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+            if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+            if (!process.env[key] || process.env[key] === "") {
+              process.env[key] = val;
+            }
+          }
+        }
+      }
+    } catch (e) {
+      console.warn(`[Magistral] Failed to load env from ${envPath}:`, e.message);
+    }
+  }
+
+  // Load candidate env files in production/dev environments
+  loadEnvFromFile(path.resolve(MAGISTRAL_DIR, "../../../survey/.env"));
+  loadEnvFromFile("/srv/cogentia/secrets/guide.env");
+  loadEnvFromFile("/srv/cogentia/secrets/ona.env");
+  loadEnvFromFile("/etc/cogentia/guide.env");
+  loadEnvFromFile("/etc/cogentia/ona.env");
+
   const apiKeys = {
-    GROQ_API_KEY: process.env.GROQ_API_KEY || "",
+    GROQ_API_KEY: process.env.GROQ_API_KEY || process.env.GROC_API_KEY || "",
     TOGETHER_API_KEY: process.env.TOGETHER_API_KEY || "",
     OPENAI_API_KEY: process.env.OPENAI_API_KEY || "",
+    MISTRAL_API_KEY: process.env.MISTRAL_API_KEY || "",
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || "",
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY || "",
   };
 
   _magistralRouter = createRouter({ map, apiKeys, log: console.warn });
@@ -770,6 +804,44 @@ function startServer() {
         const logs = trafficLog.tail(limit);
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ logs }));
+        return;
+      }
+
+      // GET .../magistral/competition
+      if (req.method === "GET" && pathname.endsWith("/magistral/competition")) {
+        const resultsPath = path.resolve(MAGISTRAL_DIR, "competition-results.json");
+        if (fs.existsSync(resultsPath)) {
+          const content = fs.readFileSync(resultsPath, "utf-8");
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(content);
+        } else {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: "No competition results found. Run scripts/run-competition.js first.",
+            })
+          );
+        }
+        return;
+      }
+
+      // POST .../magistral/competition/run
+      if (req.method === "POST" && pathname.endsWith("/magistral/competition/run")) {
+        const { spawn } = await import("child_process");
+        const scriptPath = path.resolve(MAGISTRAL_DIR, "scripts", "run-competition.js");
+
+        console.log("[Magistral] Triggering model competition benchmark...");
+        const child = spawn(process.execPath, [scriptPath], {
+          cwd: MAGISTRAL_DIR,
+          detached: true,
+          stdio: "ignore",
+        });
+        child.unref();
+
+        res.writeHead(202, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({ success: true, message: "Competition run started in background." })
+        );
         return;
       }
 


### PR DESCRIPTION
## Status

Backup-only WIP. Magistral routing tests pass, but the Models integration suite is not green; do not treat this as merge-ready or production-ready.

## What changed

- expands the Magistral model map and routing metadata
- adds UI support for launching and displaying model competition results
- adds competition runner, debugging and leaderboard scripts
- saves the 2026-07-12 competition report and structured results
- extends the models service integration path

## Validation

- syntax checks pass for all new/modified server scripts
- `pnpm --filter @inseme/magistral test` — 3/3 pass
- `pnpm --filter @inseme/models test` — 10/15 pass, 5 fail
- failures concern mock-server commands and real local LLM startup timeout
- `git diff --check` — pass after formatting cleanup
- targeted scan found no embedded credential-shaped literals

## Before merge

- diagnose the mock-server command failures
- make real-model tests optional or reliably provision the required engine/model
- review generated benchmark results for reproducibility and publication policy
- review environment-file discovery and provider-spend controls

